### PR TITLE
feat: recognize describe blocks as namespace

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -30,13 +30,13 @@ end
 function NeotestAdapter.discover_positions(path)
   local query = [[
   ((call
-      method: (identifier) @func_name (#match? @func_name "^describe")
+      method: (identifier) @func_name (#match? @func_name "^(describe|context)$")
       arguments: (argument_list (_) @namespace.name)
   )) @namespace.definition
 
 
   ((call
-    method: (identifier) @func_name (#match? @func_name "^it")
+    method: (identifier) @func_name (#eq? @func_name "it")
     arguments: (argument_list (_) @test.name)
   )) @test.definition
     ]]


### PR DESCRIPTION
Match `context` blocks as a namespace definition as well as `describe`.

Also simplify the predicate to `eq` for test definition.