### PR TITLE
[WIP] fix(block arguments)

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -78,7 +78,7 @@ end
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
-  local results_path = async.fn.tempname()
+  local results_path = 'results.json'
   local root = NeotestAdapter.root(position.path)
 
   local runner = vim.tbl_flatten({

--- a/spec/simple_example_spec.rb
+++ b/spec/simple_example_spec.rb
@@ -1,16 +1,17 @@
 require 'rspec'
 require 'sum'
 
-RSpec.describe Sum, type: :model do
+RSpec.describe Service::Sum, type: :model do
   subject(:sum) { described_class.new }
 
   context 'when passing test' do
     describe '#call' do
-      before(:all) do
+      before(:each) do
       end
 
-      it 'should return the sum of two numbers' do
-        expect(sum.call(1, 2)).to eq(3)
+      # xit is a disabled example
+      xit 'should return the sum of two numbers' do
+        expect(sum.call(1, 3)).to eq(3)
       end
     end
 

--- a/spec/simple_example_spec.rb
+++ b/spec/simple_example_spec.rb
@@ -1,10 +1,27 @@
-describe 'Some maths calculations' do
-  context 'passing test' do
+require 'rspec'
+require 'sum'
+
+RSpec.describe Sum, type: :model do
+  subject(:sum) { described_class.new }
+
+  context 'when passing test' do
+    describe '#call' do
+      before(:all) do
+      end
+
+      it 'should return the sum of two numbers' do
+        expect(sum.call(1, 2)).to eq(3)
+      end
+    end
+
+    let(:result) { 2 + 2 }
+
     it 'returns 4' do
-      expect(2 + 2).to eq(4)
+      expect(2 + 2).to eq(result)
     end
   end
-  context 'failing test' do
+
+  context 'when failing test' do
     it "doesn't return 4" do
       expect(2 + 2).to eq(5)
     end

--- a/spec/sum.rb
+++ b/spec/sum.rb
@@ -1,0 +1,5 @@
+class Sum
+  def call(a, b)
+    a + b
+  end
+end

--- a/spec/sum.rb
+++ b/spec/sum.rb
@@ -1,5 +1,9 @@
-class Sum
-  def call(a, b)
-    a + b
+# frozen_string_literal: true
+
+module Service
+  class Sum
+    def call(a, b)
+      a + b
+    end
   end
 end


### PR DESCRIPTION
Wheh there is a `type` argument passed to a block argument list should
be removed from exapmles

## with `type` definition

![image](https://user-images.githubusercontent.com/33656756/173419540-02fa0f5e-40b7-4e4f-bc94-114712081ebd.png)


## without 'type' definition

![image](https://user-images.githubusercontent.com/33656756/173419629-a5d50740-9061-4a34-a065-8cc18ea64618.png)
