### PR TITLE
test: examples for common naming conventions

### DIFF
--- a/spec/class_method_spec.rb
+++ b/spec/class_method_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe Class do
+  describe '.new' do
+    it 'handles the "." method naming convention' do
+      expect(Class.new).to be_a(Class)
+    end
+  end
+end

--- a/spec/instance_method_spec.rb
+++ b/spec/instance_method_spec.rb
@@ -1,0 +1,7 @@
+RSpec.describe String do
+  describe '#downcase' do
+    it 'handles the "#" naming convention' do
+      expect(String.new('HI').downcase).to eq('hi')
+    end
+  end
+end


### PR DESCRIPTION
In our codebase I noticed that specs using [class/instance method naming conventions](https://www.betterspecs.org/#describe) either have no results or seem to get results from unrelated tests.

![1655767003](https://user-images.githubusercontent.com/125175/174688092-bd361365-d91b-43a9-ad31-ecaf7ab116c3.png)

It looks like the RSpec example `full_description` output doesn't seem to match up with the Treesitter names we generate.

