### PR TITLE
feat: parse it_behaves_like as a test definition

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -33,7 +33,7 @@ function NeotestAdapter.discover_positions(path)
     )) @namespace.definition
 
     ((call
-      method: (identifier) @func_name (#match? @func_name "^(it|scenario)$")
+      method: (identifier) @func_name (#match? @func_name "^(it|scenario|it_behaves_like)$")
       arguments: (argument_list (_) @test.name)
     )) @test.definition
 


### PR DESCRIPTION
A test reuse strategy in RSpec is to consolidate shared blocks of code into `shared_examples` and include them into context blocks using `it_behaves_like`. These should probably be treated as test definitions.