### PR TITLE
Support for Engine specs

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -18,6 +18,7 @@ GEM
 
 PLATFORMS
   arm64-darwin-21
+  ruby
   x86_64-linux
 
 DEPENDENCIES

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -71,13 +71,35 @@ local function get_rspec_cmd()
   })
 end
 
-local path = vim.fn.expand("%")
+---Given a string, escape all the special pattern chars in it.
+---@param s string
+---@return string
+local function escapeSearchPattern(s)
+  return (
+    s:gsub("%%", "%%%%")
+      :gsub("^%^", "%%^")
+      :gsub("%$$", "%%$")
+      :gsub("%(", "%%(")
+      :gsub("%)", "%%)")
+      :gsub("%.", "%%.")
+      :gsub("%[", "%%[")
+      :gsub("%]", "%%]")
+      :gsub("%*", "%%*")
+      :gsub("%+", "%%+")
+      :gsub("%-", "%%-")
+      :gsub("%?", "%%?")
+  )
+end
 
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
   local engine_name = nil
+
+  local root = NeotestAdapter.root(position.path)
+  local path = string.gsub(position.path, escapeSearchPattern(root .. "/"), "")
+
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
   local match = vim.regex("spec/"):match_str(path)
   if match and match ~= 0 then

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -71,34 +71,13 @@ local function get_rspec_cmd()
   })
 end
 
----Given a string, escape all the special pattern chars in it.
----@param s string
----@return string
-local function escapeSearchPattern(s)
-  return (
-    s:gsub("%%", "%%%%")
-      :gsub("^%^", "%%^")
-      :gsub("%$$", "%%$")
-      :gsub("%(", "%%(")
-      :gsub("%)", "%%)")
-      :gsub("%.", "%%.")
-      :gsub("%[", "%%[")
-      :gsub("%]", "%%]")
-      :gsub("%*", "%%*")
-      :gsub("%+", "%%+")
-      :gsub("%-", "%%-")
-      :gsub("%?", "%%?")
-  )
-end
-
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
   local engine_name = nil
 
-  local root = NeotestAdapter.root(position.path)
-  local path = string.gsub(position.path, escapeSearchPattern(root .. "/"), "")
+  local path = async.fn.expand('%')
 
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
   local match = vim.regex("spec/"):match_str(path)

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -71,12 +71,13 @@ local function get_rspec_cmd()
   })
 end
 
+local path = vim.fn.expand("%")
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
   local engine_name = nil
-  local path = vim.fn.expand("%")
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
   local match = vim.regex("spec/"):match_str(path)
   if match and match ~= 0 then

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -75,6 +75,13 @@ end
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
   local position = args.tree:data()
+  local engine_name = nil
+  local path = vim.fn.expand("%")
+  -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
+  local match = vim.regex("spec/"):match_str(path)
+  if match and match ~= 0 then
+    engine_name = string.sub(path, 0, match - 1)
+  end
   local results_path = async.fn.tempname()
 
   local script_args = vim.tbl_flatten({
@@ -88,16 +95,6 @@ function NeotestAdapter.build_spec(args)
 
   local function run_by_filename()
     table.insert(script_args, position.path)
-  end
-
-  local function run_by_test_name()
-    table.insert(
-      script_args,
-      vim.tbl_flatten({
-        "-e",
-        clean_test_name(position.name),
-      })
-    )
   end
 
   local function run_by_line_number()
@@ -127,9 +124,11 @@ function NeotestAdapter.build_spec(args)
   })
 
   return {
+    cwd = engine_name,
     command = command,
     context = {
       results_path = results_path,
+      engine_name = engine_name,
     },
   }
 end
@@ -141,6 +140,7 @@ end
 ---@return neotest.Result[]
 function NeotestAdapter.results(spec, result, tree)
   local output_file = spec.context.results_path
+  local engine_name = spec.context.engine_name
 
   local ok, data = pcall(lib.files.read, output_file)
   if not ok then
@@ -154,7 +154,7 @@ function NeotestAdapter.results(spec, result, tree)
     return {}
   end
 
-  local ok, results = pcall(utils.parse_json_output, parsed_data, output_file)
+  local ok, results = pcall(utils.parse_json_output, parsed_data, output_file, engine_name)
   if not ok then
     logger.error("Failed to get test results:", output_file)
     return {}

--- a/lua/neotest-rspec/utils.lua
+++ b/lua/neotest-rspec/utils.lua
@@ -35,11 +35,16 @@ end
 ---@param parsed_rspec_json table
 ---@param output_file string
 ---@return neotest.Result[]
-M.parse_json_output = function(parsed_rspec_json, output_file)
+M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
   local tests = {}
 
   for _, result in pairs(parsed_rspec_json.examples) do
-    local test_id = result.file_path .. separator .. result.line_number
+    local test_id
+    if engine_name then
+      test_id = "./" .. engine_name .. string.sub(result.file_path, 2) .. separator .. result.line_number
+    else
+      test_id = result.file_path .. separator .. result.line_number
+    end
 
     logger.debug("RSpec ID:", { test_id })
 

--- a/lua/neotest-rspec/utils.lua
+++ b/lua/neotest-rspec/utils.lua
@@ -38,6 +38,8 @@ end
 M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
   local tests = {}
 
+  print(vim.inspect(parsed_rspec_json))
+
   for _, result in pairs(parsed_rspec_json.examples) do
     local test_id
     if engine_name then

--- a/lua/neotest-rspec/utils.lua
+++ b/lua/neotest-rspec/utils.lua
@@ -38,8 +38,6 @@ end
 M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
   local tests = {}
 
-  print(vim.inspect(parsed_rspec_json))
-
   for _, result in pairs(parsed_rspec_json.examples) do
     local test_id
     if engine_name then

--- a/test_engine/spec/basic_spec.rb
+++ b/test_engine/spec/basic_spec.rb
@@ -1,0 +1,22 @@
+require 'spec_helper'
+
+module Nested
+  class Foo
+    def call
+      'foo'
+    end
+  end
+end
+
+describe Nested::Foo do
+  it 'adds two numbers together' do
+    expect(2 + 2).to eq(4)
+  end
+
+  # run `:lua require('neotest').run.run()` on line 17 won't get test result
+  describe '#call' do
+    it 'returns foo' do
+      expect(described_class.new.call).to eq('foo')
+    end
+  end
+end

--- a/test_engine/spec/spec_helper.rb
+++ b/test_engine/spec/spec_helper.rb
@@ -1,0 +1,3 @@
+RSpec.configure do |config|
+  config.order = 'random'
+end

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -6,16 +6,16 @@ describe("is_test_file", function()
     assert.equals(true, plugin.is_test_file("./spec/foo_spec.rb"))
   end)
 
-  it('does not match plain ruby files', function()
+  it("does not match plain ruby files", function()
     assert.equals(false, plugin.is_test_file("./lib/foo.rb"))
   end)
 end)
 
-describe('discover_positions', function()
+describe("discover_positions", function()
   async.it("provides meaningful names from a basic spec", function()
     local positions = plugin.discover_positions("./spec/nested/basic_spec.rb"):to_list()
 
-    local expected_output  = {
+    local expected_output = {
       {
         name = "basic_spec.rb",
         type = "file",
@@ -29,9 +29,40 @@ describe('discover_positions', function()
           {
             name = "'adds two numbers together'",
             type = "test",
-          }
-        }
-      }
+          },
+        },
+      },
+    }
+
+    assert.equals(expected_output[1].name, positions[1].name)
+    assert.equals(expected_output[1].type, positions[1].type)
+    assert.equals(expected_output[2][1].name, positions[2][1].name)
+    assert.equals(expected_output[2][1].type, positions[2][1].type)
+    assert.equals(expected_output[2][2][1].name, positions[2][2][1].name)
+    assert.equals(expected_output[2][2][1].type, positions[2][2][1].type)
+  end)
+end)
+
+describe("engine test", function()
+  async.it("provides meaningful names from a basic engine spec", function()
+    local positions = plugin.discover_positions("./test_engine/spec/basic_spec.rb"):to_list()
+    local expected_output = {
+      {
+        name = "basic_spec.rb",
+        type = "file",
+      },
+      {
+        {
+          name = "Nested::Foo",
+          type = "namespace",
+        },
+        {
+          {
+            name = "'adds two numbers together'",
+            type = "test",
+          },
+        },
+      },
     }
 
     assert.equals(expected_output[1].name, positions[1].name)

--- a/tests/utils_spec.lua
+++ b/tests/utils_spec.lua
@@ -14,10 +14,7 @@ describe("generate_treesitter_id", function()
       type = "test",
     }
 
-    assert.equals(
-      "./spec/basic_spec.rb::2",
-      utils.generate_treesitter_id(ts)
-    )
+    assert.equals("./spec/basic_spec.rb::2", utils.generate_treesitter_id(ts))
   end)
 end)
 
@@ -46,5 +43,31 @@ describe("parse_json_output", function()
     }
 
     assert.are.same(expected_output, utils.parse_json_output(parsed_rspec_json, "/tmp/nvimhYaIPj/3"))
+  end)
+
+  it("works with engine specs", function()
+    local parsed_rspec_json = {
+      examples = {
+        {
+          id = "./spec/basic_spec.rb[1:1]",
+          description = "adds two numbers together",
+          full_description = "Maths adds two numbers together",
+          status = "passed",
+          file_path = "./spec/basic_spec.rb",
+          line_number = 2,
+          run_time = 0.000192247,
+        },
+      },
+    }
+
+    local expected_output = {
+      ["./engine_name/spec/basic_spec.rb::2"] = {
+        output_file = "/tmp/nvimhYaIPj/3",
+        short = "./SPEC/BASIC_SPEC.RB\n-> PASSED - adds two numbers together",
+        status = "passed",
+      },
+    }
+
+    assert.are.same(expected_output, utils.parse_json_output(parsed_rspec_json, "/tmp/nvimhYaIPj/3", "engine_name"))
   end)
 end)


### PR DESCRIPTION
When you launch nvim from the root of a rails project with an engine and then try to run the engine tests things would break. 

Now there's some detection and some special parsing to make it work. 