### PR TITLE
Filter directories

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -29,7 +29,7 @@ end
 ---@return boolean
 function NeotestAdapter.filter_dir(name, rel_path, root)
   local _, count = rel_path:gsub("/", "")
-  if rel_path:match("spec") or count <= 1  then
+  if rel_path:match("spec") or count < 1  then
     return true
   end
   return false

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -29,7 +29,10 @@ end
 ---@return boolean
 function NeotestAdapter.filter_dir(name, rel_path, root)
   local _, count = rel_path:gsub("/", "")
-  return rel_path:match("spec") or count < 1
+  if rel_path:match("spec") or count < 1 then
+    return true
+  end
+  return false
 end
 
 ---Given a file path, parse all the tests within it.

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -21,6 +21,20 @@ function NeotestAdapter.is_test_file(file_path)
   return vim.endswith(file_path, "_spec.rb")
 end
 
+---Filter directories when searching for test files
+---@async
+---@param name string Name of directory
+---@param rel_path string Path to directory, relative to root
+---@param root string Root directory of project
+---@return boolean
+function NeotestAdapter.filter_dir(name, rel_path, root)
+  local _, count = rel_path:gsub("/", "")
+  if rel_path:match("spec") or count <= 1  then
+    return true
+  end
+  return false
+end
+
 ---Given a file path, parse all the tests within it.
 ---@async
 ---@param file_path string Absolute file path

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -29,10 +29,7 @@ end
 ---@return boolean
 function NeotestAdapter.filter_dir(name, rel_path, root)
   local _, count = rel_path:gsub("/", "")
-  if rel_path:match("spec") or count < 1  then
-    return true
-  end
-  return false
+  return rel_path:match("spec") or count < 1
 end
 
 ---Given a file path, parse all the tests within it.

--- a/tests/init_spec.lua
+++ b/tests/init_spec.lua
@@ -11,6 +11,28 @@ describe("is_test_file", function()
   end)
 end)
 
+describe("filter_dir", function()
+  -- note that even though these tests suggest that `engine/things/spec` would be approved, 
+  -- `engine/things` would return false, so `engine/things/spec` would never be searched by
+  -- neotest
+  local root = "/home/name/projects"
+  it("allows spec", function()
+    assert.equals(true, plugin.filter_dir("spec", "spec", root))
+  end)
+  it("allows sub directories one deep (for engines)", function()
+    assert.equals(true, plugin.filter_dir("test_engine", "test_engine", root))
+  end)
+  it("allows paths that contain spec", function()
+    assert.equals(true, plugin.filter_dir("spec", "test_engine/spec", root))
+  end)
+  it("allows a long path with spec at the start", function()
+    assert.equals(true, plugin.filter_dir("billing_service", "spec/controllers/billing_service", root))
+  end)
+  it("disallows paths without spec, more that one sub dir deep", function()
+    assert.equals(false, plugin.filter_dir("models", "app/models", root))
+  end)
+end)
+
 describe("discover_positions", function()
   async.it("provides meaningful names from a basic spec", function()
     local positions = plugin.discover_positions("./spec/nested/basic_spec.rb"):to_list()


### PR DESCRIPTION
Implements the `filter_dir` method in the [neotest adapter interface](https://github.com/nvim-neotest/neotest/blob/master/lua/neotest/adapters/interface.lua#L14-L20)

This reduces the initial load time of the neotest plugin in large repos by a substantial margin (20s to 9s in my work rails repo)

Currently using some simple rules. If the path has "spec" in it, it's good. If it doesn't, and it's got a "/" in it, it's bad. 

These rules allow "engine/spec" to get picked up as well as "spec", but would miss "engine/something/spec"

afaik, that last case is not common or recommended? I'm fairly new to this whole ruby thing. So let me know if that's a problem. 