### PR TITLE
feat: Support descriptionless it blocks

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -55,6 +55,11 @@ function NeotestAdapter.discover_positions(path)
       method: (identifier) @func_name (#eq? @func_name "it")
       block: (block (_) @test.name)
     )) @test.definition
+
+    ((call
+      method: (identifier) @func_name (#eq? @func_name "it")
+      block: (do_block (_) @test.name)
+    )) @test.definition
   ]]
 
   return lib.treesitter.parse_positions(path, query, {

--- a/spec/one_liner_syntax_spec.rb
+++ b/spec/one_liner_syntax_spec.rb
@@ -5,4 +5,9 @@ RSpec.describe Array do
   describe 'when first created' do
     it { is_expected.to be_empty }
   end
+  describe 'when first created' do
+    it do
+      is_expected.to be_empty
+    end
+  end
 end


### PR DESCRIPTION
Thanks for the great plugin!

I've run across a case that's not detected yet. It's possible to define "one-liner" tests with a multi-line block:

```ruby
it do
  expect([]).to be_empty
end
```

I've added a treesitter query to detect this case.