### PR TITLE
chore: upgrade github action

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,7 +8,7 @@ jobs:
     runs-on: ubuntu-20.04
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v3
 
       - name: Set up Neovim
         run: |


### PR DESCRIPTION
Upgrades to `actions/checkout@v3` to resolve the following warning on CI runs:

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2.