### PR TITLE
chore: simplify ci workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,32 +10,9 @@ jobs:
     steps:
       - uses: actions/checkout@v3
 
-      - name: Set up Neovim
-        run: |
-          wget -q https://github.com/neovim/neovim/releases/download/v0.8.3/nvim-linux64.deb -O /tmp/nvim.deb
-          sudo dpkg -i /tmp/nvim.deb
-
-      - name: Install tree-sitter CLI
-        run: |
-          npm install -g tree-sitter-cli
-
-      - name: Install dependencies
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y git curl unzip xz-utils
-
-      - name: Set up nvim-treesitter
-        run: |
-          mkdir -p ~/.config/nvim
-          echo 'set rtp+=~/.local/share/nvim/site/pack/nvim-treesitter/start/nvim-treesitter' > ~/.config/nvim/init.vim
-          echo 'lua << EOF' >> ~/.config/nvim/init.vim
-          echo 'require("nvim-treesitter.configs").setup({ ensure_installed = "ruby" })' >> ~/.config/nvim/init.vim
-          echo 'EOF' >> ~/.config/nvim/init.vim
-
-      - name: Install nvim-treesitter
-        run: |
-          git clone https://github.com/nvim-treesitter/nvim-treesitter.git ~/.local/share/nvim/site/pack/nvim-treesitter/start/nvim-treesitter
-          nvim --headless -c "TSInstallSync ruby" -c "q"
+      - uses: rhysd/action-setup-vim@v1
+        with:
+          neovim: true
 
       - name: Run tests
         run: |


### PR DESCRIPTION
* Use action to install the latest neovim. The deb is not available for the latest versions, see https://github.com/neovim/neovim/pull/22773
* No need to install nvim-treesitter. This is done in the Makefile
* Remove install dependencies step. The runner already has these dependencies see https://github.com/actions/runner-images/blob/main/images/linux/Ubuntu2004-Readme.md

I know the tests are failing right now but at least they fail faster 😅