### PR TITLE
Ensure we're only checking the start of the path

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -87,7 +87,7 @@ function NeotestAdapter.build_spec(args)
   local path = async.fn.expand("%")
 
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
-  local match = vim.regex("spec/"):match_str(path)
+  local match = vim.regex("^spec/"):match_str(path)
   if match and match ~= 0 then engine_name = string.sub(path, 0, match - 1) end
   local results_path = async.fn.tempname()
 


### PR DESCRIPTION
Currently the match check can grab a spec path not at the root. I.e. for domains/example/spec/example_spec.rb it will match spec/example_spec.rb and use that spec folder as the root. This can cause the run to use the wrong root path if using something like packwerk. By specifying start of line in the regex we guarantee we are only checking the root spec.