### PR TITLE
fix: add a query to catch one liner

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -66,6 +66,12 @@ function NeotestAdapter.discover_positions(path)
     )) @test.definition
 
     ((call
+      method: (identifier) @func_name (#eq? @func_name "it")
+      block: (do_block (_) @test.name)
+      !arguments
+    )) @test.definition
+
+    ((call
       method: (identifier) @func_name (#match? @func_name "^(it|scenario|it_behaves_like)$")
       arguments: (argument_list (_) @test.name)
     )) @test.definition

--- a/spec/one_liner_syntax/one_liner_syntax_spec.rb
+++ b/spec/one_liner_syntax/one_liner_syntax_spec.rb
@@ -9,5 +9,8 @@ RSpec.describe Array do
     it do
       is_expected.to be_empty
     end
+    it do
+      expect(true).to be(true)
+    end
   end
 end

--- a/spec/one_liner_syntax/one_liner_syntax_spec_04.commands
+++ b/spec/one_liner_syntax/one_liner_syntax_spec_04.commands
@@ -1,0 +1,2 @@
+:13
+:lua require("neotest").run.run()

--- a/spec/one_liner_syntax/one_liner_syntax_spec_04.expected
+++ b/spec/one_liner_syntax/one_liner_syntax_spec_04.expected
@@ -1,0 +1,1 @@
+./SPEC/ONE_LINER_SYNTAX/ONE_LINER_SYNTAX_SPEC.RB@@PASSED@@is expected to equal true


### PR DESCRIPTION
Ref #50 

```
nvim --headless --clean \
-u tests/minimal_init.lua \
-c "PlenaryBustedDirectory tests/unit/core { minimal_init = 'tests/minimal_init.lua' }"
Starting...Scheduling: tests/unit/core/plugin_spec.lua
Scheduling: tests/unit/core/treesitter_installed_spec.lua
Scheduling: tests/unit/core/utils_spec.lua

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/plugin_spec.lua
Success ||      is_test_file matches rspec files
Success ||      is_test_file does not match plain ruby files
Success ||      filter_dir allows spec
Success ||      filter_dir allows sub directories one deep (for engines)
Success ||      filter_dir allows paths that contain spec
Success ||      filter_dir allows a long path with spec at the start

Success:        6
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/treesitter_installed_spec.lua
Success ||      Treesitter check should check if Treesitter is installed and working
Success ||      Treesitter check should check if the Ruby parser is installed and working

Success:        2
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/utils_spec.lua
Success ||      generate_treesitter_id forms an id
Success ||      parse_json_output extracts summary info from a passed rspec example
Success ||      parse_json_output works with engine specs

Success:        3
Failed :        0
Errors :        0
========================================
nvim --headless --clean \
nvim --headless --clean \
-u tests/minimal_init.lua \
-c "PlenaryBustedDirectory tests/unit/core { minimal_init = 'tests/minimal_init.lua' }"
Starting...Scheduling: tests/unit/core/plugin_spec.lua
Scheduling: tests/unit/core/treesitter_installed_spec.lua
Scheduling: tests/unit/core/utils_spec.lua

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/treesitter_installed_spec.lua
Success ||      Treesitter check should check if Treesitter is installed and working
Success ||      Treesitter check should check if the Ruby parser is installed and working

Success:        2
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/plugin_spec.lua
Success ||      is_test_file matches rspec files
Success ||      is_test_file does not match plain ruby files
Success ||      filter_dir allows spec
Success ||      filter_dir allows sub directories one deep (for engines)
Success ||      filter_dir allows paths that contain spec
Success ||      filter_dir allows a long path with spec at the start

Success:        6
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/utils_spec.lua
Success ||      generate_treesitter_id forms an id
Success ||      parse_json_output extracts summary info from a passed rspec example
Success ||      parse_json_output works with engine specs

Success:        3
Failed :        0
Errors :        0
========================================
nvim --headless --clean \
-u tests/minimal_init.lua \
-c "PlenaryBustedDirectory tests/unit/core { minimal_init = 'tests/minimal_init.lua' }"
Starting...Scheduling: tests/unit/core/plugin_spec.lua
Scheduling: tests/unit/core/treesitter_installed_spec.lua
Scheduling: tests/unit/core/utils_spec.lua

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/treesitter_installed_spec.lua
Success ||      Treesitter check should check if Treesitter is installed and working
Success ||      Treesitter check should check if the Ruby parser is installed and working

Success:        2
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/plugin_spec.lua
Success ||      is_test_file matches rspec files
Success ||      is_test_file does not match plain ruby files
Success ||      filter_dir allows spec
Success ||      filter_dir allows sub directories one deep (for engines)
Success ||      filter_dir allows paths that contain spec
Success ||      filter_dir allows a long path with spec at the start

Success:        6
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/core/utils_spec.lua
Success ||      generate_treesitter_id forms an id
Success ||      parse_json_output extracts summary info from a passed rspec example
Success ||      parse_json_output works with engine specs

Success:        3
Failed :        0
Errors :        0
========================================
nvim --headless --clean \
-u tests/minimal_init.lua \
-c "PlenaryBustedDirectory tests/unit/rspec { minimal_init = 'tests/minimal_init.lua' }"
Starting...Scheduling: tests/unit/rspec/class_methods_spec.lua
Scheduling: tests/unit/rspec/basic_spec.lua
Scheduling: tests/unit/rspec/descriptionless_blocks_spec.lua
Scheduling: tests/unit/rspec/blockless_it_spec.lua
Scheduling: tests/unit/rspec/one_liner_syntax_spec.lua

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/rspec/descriptionless_blocks_spec.lua
Success ||      Testing descriptionless blocks (file: /home/eric/personal/neovim/neotest-rspec/spec/descriptionless_blocks/descriptionless_blocks_spec_01)

Success:        1
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/rspec/class_methods_spec.lua
Success ||      Testing class methods (file: /home/eric/personal/neovim/neotest-rspec/spec/class_methods/class_methods_spec_01)
Success ||      Testing class methods (file: /home/eric/personal/neovim/neotest-rspec/spec/class_methods/class_methods_spec_02)

Success:        2
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/rspec/basic_spec.lua
Success ||      Testing basic specs (file: /home/eric/personal/neovim/neotest-rspec/spec/basic/basic_spec_01)
Success ||      Testing basic specs (file: /home/eric/personal/neovim/neotest-rspec/spec/basic/basic_spec_02)
Success ||      Testing basic specs (file: /home/eric/personal/neovim/neotest-rspec/spec/basic/basic_spec_03)

Success:        3
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/rspec/one_liner_syntax_spec.lua
Success ||      Testing one liner syntax (file: /home/eric/personal/neovim/neotest-rspec/spec/one_liner_syntax/one_liner_syntax_spec_01)
Success ||      Testing one liner syntax (file: /home/eric/personal/neovim/neotest-rspec/spec/one_liner_syntax/one_liner_syntax_spec_02)
Success ||      Testing one liner syntax (file: /home/eric/personal/neovim/neotest-rspec/spec/one_liner_syntax/one_liner_syntax_spec_03)

Success:        3
Failed :        0
Errors :        0
========================================

========================================
Testing:        /home/eric/personal/neovim/neotest-rspec/tests/unit/rspec/blockless_it_spec.lua
Success ||      Testing blockless its (file: /home/eric/personal/neovim/neotest-rspec/spec/blockless_it/blockless_it_spec_01)
Success ||      Testing blockless its (file: /home/eric/personal/neovim/neotest-rspec/spec/blockless_it/blockless_it_spec_02)
Success ||      Testing blockless its (file: /home/eric/personal/neovim/neotest-rspec/spec/blockless_it/blockless_it_spec_03)
Success ||      Testing blockless its (file: /home/eric/personal/neovim/neotest-rspec/spec/blockless_it/blockless_it_spec_04)
Success ||      Testing blockless its (file: /home/eric/personal/neovim/neotest-rspec/spec/blockless_it/blockless_it_spec_05)

Success:        5
Failed :        0
Errors :        0
========================================
```
