### PR TITLE
feat: Add support for running rspec in a docker container.

### DIFF
--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -21,7 +21,7 @@ M.transform_spec_path = function(path)
 end
 
 M.results_path = function()
-  return async.fn.tempname()
+  return require("neotest.async").fn.tempname()
 end
 
 return M

--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -16,4 +16,12 @@ M.get_filter_dirs = function()
   return { ".git", "node_modules" }
 end
 
+M.transform_spec_path = function(path)
+  return path
+end
+
+M.results_path = function()
+  return async.fn.tempname()
+end
+
 return M


### PR DESCRIPTION
Hello, this PR adds support for running rspec in a docker container by adding a couple of new config options:

- `transform_spec_path` allows the spec path to be modified before being passed to rspec. When running in a docker container a relative path needs to be used instead of an absolute path.
- `results_path` allows the results file to be modified so that it's available to both the docker container and host.