### PR TITLE
feat: add support for included examples

### DIFF
--- a/lua/neotest-rspec/utils.lua
+++ b/lua/neotest-rspec/utils.lua
@@ -57,11 +57,12 @@ M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
   local tests = {}
 
   for _, result in pairs(parsed_rspec_json.examples) do
+    local file_path = string.gsub(result.id, "(.+)%[.+%]", "%1")
     local test_id
     if engine_name then
-      test_id = "./" .. engine_name .. string.sub(result.file_path, 2) .. separator .. result.line_number
+      test_id = "./" .. engine_name .. string.sub(file_path, 2) .. separator .. result.line_number
     else
-      test_id = result.file_path .. separator .. result.line_number
+      test_id = file_path .. separator .. result.line_number
     end
 
     logger.debug("RSpec ID:", { test_id })
@@ -70,8 +71,8 @@ M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
 
     tests[test_id] = {
       status = result.status,
-      short = string.upper(result.file_path) .. "\n-> " .. string.upper(result.status) .. " - " .. result.description,
-      testing_output = string.upper(result.file_path)
+      short = string.upper(file_path) .. "\n-> " .. string.upper(result.status) .. " - " .. result.description,
+      testing_output = string.upper(file_path)
         .. "@@"
         .. string.upper(result.status)
         .. "@@"

--- a/lua/neotest-rspec/utils.lua
+++ b/lua/neotest-rspec/utils.lua
@@ -58,6 +58,10 @@ M.parse_json_output = function(parsed_rspec_json, output_file, engine_name)
 
   for _, result in pairs(parsed_rspec_json.examples) do
     local file_path = string.gsub(result.id, "(.+)%[.+%]", "%1")
+    if string.match(file_path, "^/") then
+      file_path = "." .. file_path
+    end
+
     local test_id
     if engine_name then
       test_id = "./" .. engine_name .. string.sub(file_path, 2) .. separator .. result.line_number

--- a/spec/included_examples/included_examples_spec.rb
+++ b/spec/included_examples/included_examples_spec.rb
@@ -1,0 +1,5 @@
+require_relative "./shared_examples"
+
+RSpec.describe 'Included Examples' do
+  it_behaves_like 'to be included'
+end

--- a/spec/included_examples/shared_examples.rb
+++ b/spec/included_examples/shared_examples.rb
@@ -1,0 +1,5 @@
+RSpec.shared_examples 'to be included' do
+  it 'adds two numbers together' do
+    expect(2+2).to eq(4)
+  end
+end

--- a/tests/unit/core/utils_spec.lua
+++ b/tests/unit/core/utils_spec.lua
@@ -72,4 +72,31 @@ describe("parse_json_output", function()
 
     assert.are.same(expected_output, utils.parse_json_output(parsed_rspec_json, "/tmp/nvimhYaIPj/3", "engine_name"))
   end)
+
+  it("works with included examples", function()
+    local parsed_rspec_json = {
+      examples = {
+        {
+          id = "./spec/included_examples/included_examples_spec.rb[1:1:1]",
+          description = "adds two numbers together",
+          full_description = "Included Examples behaves like to be included adds two numbers together",
+          status = "passed",
+          file_path = "./spec/included_examples/shared_examples.rb",
+          line_number = 2,
+          run_time = 0.002228,
+        },
+      },
+    }
+
+    local expected_output = {
+      ["./spec/included_examples/included_examples_spec.rb::2"] = {
+        output_file = "/tmp/nvimhYaIPj/3",
+        short = "./SPEC/INCLUDED_EXAMPLES/INCLUDED_EXAMPLES_SPEC.RB\n-> PASSED - adds two numbers together",
+        status = "passed",
+        testing_output = "./SPEC/INCLUDED_EXAMPLES/INCLUDED_EXAMPLES_SPEC.RB@@PASSED@@adds two numbers together",
+      },
+    }
+
+    assert.are.same(expected_output, utils.parse_json_output(parsed_rspec_json, "/tmp/nvimhYaIPj/3"))
+  end)
 end)


### PR DESCRIPTION
add support for examples included with `it_behaves_like`