### PR TITLE
[feat] Pass position_type to allow more rspec_cmd customization

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,11 +91,7 @@ The command used to run tests can be changed via the `rspec_cmd` option:
 
 ```lua
 require("neotest-rspec")({
-  -- Optionally your function can take a position_type which is one of:
-  -- - "file"
-  -- - "test"
-  -- - "dir"
-  rspec_cmd = function(position_type)
+  rspec_cmd = function()
     return vim.tbl_flatten({
       "bundle",
       "exec",
@@ -104,6 +100,57 @@ require("neotest-rspec")({
   end
 })
 ```
+
+One issue you can run into is when you use generated tests:
+
+```ruby
+RSpec.describe SomeClass do
+  describe "some feature" do
+    FIXTURES.each do |method, path|
+      it "does something with the #{method} and #{path}" do
+        # ...
+      end
+    end
+  end
+end
+```
+
+The test will show as passing if any one of the tests pass instead of if all of
+them pass. You can change the test command to use `--fail-fast` to fix this.
+However now your other tests will all fail if even a single test fails.
+
+To solve this you can customize your command depending on the type of test you
+are running by using the optional positional argument `position_type`
+
+
+```lua
+require("neotest-rspec")({
+  -- Optionally your function can take a position_type which is one of:
+  -- - "file"
+  -- - "test"
+  -- - "dir"
+  rspec_cmd = function(position_type)
+    if position_type == "test" then
+      return vim.tbl_flatten({
+        "bundle",
+        "exec",
+        "rspec",
+        "--fail-fast"
+      })
+    else
+      return vim.tbl_flatten({
+        "bundle",
+        "exec",
+        "rspec",
+      })
+    end
+ end
+})
+```
+
+Now when you run your tests from a single test it will fail fast and show the
+correct error on your generated tests. When you run the whole file it won't fail
+fast and a single error won't cause all your other tests to fail.
 
 ### Setting the root directory
 

--- a/README.md
+++ b/README.md
@@ -91,7 +91,11 @@ The command used to run tests can be changed via the `rspec_cmd` option:
 
 ```lua
 require("neotest-rspec")({
-  rspec_cmd = function()
+  -- Optionally your function can take a position_type which is one of:
+  -- - "file"
+  -- - "test"
+  -- - "dir"
+  rspec_cmd = function(position_type)
     return vim.tbl_flatten({
       "bundle",
       "exec",

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -127,7 +127,7 @@ function NeotestAdapter.build_spec(args)
   if position.type == "dir" and vim.bo.filetype == "neotest-summary" then run_by_filename() end
 
   local command = vim.tbl_flatten({
-    config.get_rspec_cmd(),
+    config.get_rspec_cmd(position.type),
     script_args,
   })
 


### PR DESCRIPTION
I have an RSpec test that uses data to generate tests such as:

```ruby
RSpec.describe SomeClass do
  describe "some feature" do
    FIXTURES.each do |method, path|
      it "does something with the #{method} and #{path}" do
        # ...
      end
    end
  end
end
```

The problem is that running a typical `bundle exec rspec` with the runner will show this passing even if some of the generated tests fail. I can fix it by making my command `bundle exec rspec --fail-fast` however now the entire test file will fail if a single test does.

This PR enables someone to change the rspec command depending on the type of test they ran, which would fix my issue like so:

```lua
rspec_cmd = function(position_type)
  if position_type == "test" then
    return vim.tbl_flatten({
      "bundle",
      "exec",
      "rspec",
      "--fail-fast"
    })
  else
    return vim.tbl_flatten({
      "bundle",
      "exec",
      "rspec",
    })
  end
end
```

As a side note, I ran the test suite when I started but there were already failing specs. I made sure no new specs failed but I didn't fix those specs before implementing. Happy to change this PR with any changes you want.