### PR TITLE
tests: make sure we have external nio when running tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,16 +1,17 @@
 NEOTEST_DIR = misc/neotest
+NIO_DIR = misc/nio
 PLENARY_DIR = misc/plenary
 TREESITTER_DIR = misc/treesitter
 TEST_DIR = tests/unit
 
 test: test_core test_rspec
 
-test_core: $(NEOTEST_DIR) $(PLENARY_DIR) $(TREESITTER_DIR)
+test_core: $(NEOTEST_DIR) $(NIO_DIR) $(PLENARY_DIR) $(TREESITTER_DIR)
 	nvim --headless --clean \
 	-u tests/minimal_init.lua \
 	-c "PlenaryBustedDirectory $(TEST_DIR)/core { minimal_init = 'tests/minimal_init.lua' }"
 
-test_rspec: $(NEOTEST_DIR) $(PLENARY_DIR) $(TREESITTER_DIR)
+test_rspec: $(NEOTEST_DIR) $(NIO_DIR) $(PLENARY_DIR) $(TREESITTER_DIR)
 	nvim --headless --clean \
 	-u tests/minimal_init.lua \
 	-c "PlenaryBustedDirectory $(TEST_DIR)/rspec { minimal_init = 'tests/minimal_init.lua' }"
@@ -18,6 +19,10 @@ test_rspec: $(NEOTEST_DIR) $(PLENARY_DIR) $(TREESITTER_DIR)
 $(NEOTEST_DIR):
 	git clone --depth=1 --no-single-branch https://github.com/nvim-neotest/neotest $(NEOTEST_DIR)
 	@rm -rf $(NEOTEST_DIR)/.git
+
+$(NIO_DIR):
+	git clone --depth=1 --no-single-branch https://github.com/nvim-neotest/nvim-nio $(NIO_DIR)
+	@rm -rf $(NIO_DIR)/.git
 
 $(PLENARY_DIR):
 	git clone --depth=1 --branch v0.1.3 https://github.com/nvim-lua/plenary.nvim $(PLENARY_DIR)

--- a/tests/minimal_init.lua
+++ b/tests/minimal_init.lua
@@ -3,6 +3,7 @@ vim.bo.swapfile = false
 
 vim.cmd([[set runtimepath+=.]])
 vim.cmd([[set runtimepath+=./misc/neotest]])
+vim.cmd([[set runtimepath+=./misc/nio]])
 vim.cmd([[set runtimepath+=./misc/plenary]])
 vim.cmd([[set runtimepath+=./misc/treesitter]])
 


### PR DESCRIPTION
nvim-neotest requires external plugin nvim-nio to run. This was added as a breaking change in https://github.com/nvim-neotest/neotest/pull/337