### PR TITLE
feat: add support for rspec-its style specs

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,3 +1,4 @@
 source "https://rubygems.org"
 
 gem "rspec"
+gem "rspec-its"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -11,6 +11,9 @@ GEM
     rspec-expectations (3.11.0)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
+    rspec-its (1.3.0)
+      rspec-core (>= 3.0.0)
+      rspec-expectations (>= 3.0.0)
     rspec-mocks (3.11.1)
       diff-lcs (>= 1.2.0, < 2.0)
       rspec-support (~> 3.11.0)
@@ -23,6 +26,7 @@ PLATFORMS
 
 DEPENDENCIES
   rspec
+  rspec-its
 
 BUNDLED WITH
    2.3.14

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -61,18 +61,18 @@ function NeotestAdapter.discover_positions(path)
     )) @namespace.definition
 
     ((call
-      method: (identifier) @func_name (#match? @func_name "^(it|specify)$")
+      method: (identifier) @func_name (#match? @func_name "^(it|its|specify)$")
       block: (block (_) @test.name)
     )) @test.definition
 
     ((call
-      method: (identifier) @func_name (#match? @func_name "^(it|specify)$")
+      method: (identifier) @func_name (#match? @func_name "^(it|its|specify)$")
       block: (do_block (_) @test.name)
       !arguments
     )) @test.definition
 
     ((call
-      method: (identifier) @func_name (#match? @func_name "^(it|scenario|it_behaves_like)$")
+      method: (identifier) @func_name (#match? @func_name "^(it|its|scenario|it_behaves_like)$")
       arguments: (argument_list (_) @test.name)
     )) @test.definition
   ]]

--- a/spec/its/its_spec.rb
+++ b/spec/its/its_spec.rb
@@ -1,0 +1,26 @@
+require 'rspec/its'
+require 'ostruct'
+
+RSpec.describe 'its examples' do
+  describe 'hash access' do
+    subject { { foo: 1, bar: 2 } }
+
+    its([:foo]) { is_expected.to eq(1) }
+
+    its([:bar]) do
+      is_expected.to eq(2)
+    end
+  end
+
+  describe 'object access' do
+    subject { OpenStruct.new(foo: 4, bar: 5, baz: 6) }
+
+    its(:foo) { is_expected.to eq(4) }
+
+    its(:bar) do
+      is_expected.to eq(5)
+    end
+
+    its('baz') { is_expected.to eq(6) }
+  end
+end

--- a/spec/its/its_spec_01.commands
+++ b/spec/its/its_spec_01.commands
@@ -1,0 +1,2 @@
+:8
+:lua require("neotest").run.run()

--- a/spec/its/its_spec_01.expected
+++ b/spec/its/its_spec_01.expected
@@ -1,0 +1,1 @@
+./SPEC/ITS/ITS_SPEC.RB@@PASSED@@is expected to eq 1

--- a/spec/its/its_spec_02.commands
+++ b/spec/its/its_spec_02.commands
@@ -1,0 +1,2 @@
+:11
+:lua require("neotest").run.run()

--- a/spec/its/its_spec_02.expected
+++ b/spec/its/its_spec_02.expected
@@ -1,0 +1,1 @@
+./SPEC/ITS/ITS_SPEC.RB@@PASSED@@is expected to eq 2

--- a/spec/its/its_spec_03.commands
+++ b/spec/its/its_spec_03.commands
@@ -1,0 +1,2 @@
+:18
+:lua require("neotest").run.run()

--- a/spec/its/its_spec_03.expected
+++ b/spec/its/its_spec_03.expected
@@ -1,0 +1,1 @@
+./SPEC/ITS/ITS_SPEC.RB@@PASSED@@is expected to eq 4

--- a/spec/its/its_spec_04.commands
+++ b/spec/its/its_spec_04.commands
@@ -1,0 +1,2 @@
+:20
+:lua require("neotest").run.run()

--- a/spec/its/its_spec_04.expected
+++ b/spec/its/its_spec_04.expected
@@ -1,0 +1,1 @@
+./SPEC/ITS/ITS_SPEC.RB@@PASSED@@is expected to eq 5

--- a/spec/its/its_spec_05.commands
+++ b/spec/its/its_spec_05.commands
@@ -1,0 +1,2 @@
+:24
+:lua require("neotest").run.run()

--- a/spec/its/its_spec_05.expected
+++ b/spec/its/its_spec_05.expected
@@ -1,0 +1,1 @@
+./SPEC/ITS/ITS_SPEC.RB@@PASSED@@is expected to eq 6

--- a/tests/unit/rspec/its_spec.lua
+++ b/tests/unit/rspec/its_spec.lua
@@ -1,0 +1,3 @@
+local test = require("tests.template")
+
+test.describe("Testing its specs", "its_spec.rb")


### PR DESCRIPTION
This adds support for [rspec-its](https://github.com/rspec/rspec-its).

It's an outdated style of specs but I happen to work on older projects that use it. It would be nice if the support were baked into this project. 😄 