### PR TITLE
Add support for dap to debug tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -246,6 +246,16 @@ To test a directory run `require("neotest").run.run("path/to/directory")`
 To test the full test suite run `require("neotest").run.run("path/to/root_project")`
 e.g. `require("neotest").run.run(vim.fn.getcwd())`, presuming that vim's directory is the same as the project root.
 
+#### Debug test
+
+In order to enable DAP for a test or test suite, ensure that [nvim-dap](https://github.com/mfussenegger/nvim-dap) and [nvim-dap-ruby](https://github.com/suketa/nvim-dap-ruby) are installed and follow the [strategies](https://github.com/nvim-neotest/neotest?tab=readme-ov-file#strategies) docs. An example snippet can be found below.
+
+```lua
+require("neotest").run.run({ strategy = "dap" })
+```
+
+This will run the closest test under DAP.
+
 ## :gift: Contributing
 
 This project is maintained by the Neovim Ruby community. Please raise a PR if you are interested in adding new functionality or fixing any bugs. When submitting a bug, please include an example spec that can be tested.

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -120,6 +120,23 @@ function NeotestAdapter.build_spec(args)
     )
   end
 
+  local function get_strategy_config(strategy, command, cwd)
+    local strategy_config = {
+      dap = function()
+        return {
+          name = "Debug RSpec Tests",
+          type = "ruby",
+          args = { unpack(command, 2) },
+          command = command[1],
+          cwd = cwd or "${workspaceFolder}",
+          current_line = true,
+          random_port = true,
+        }
+      end,
+    }
+    if strategy_config[strategy] then return strategy_config[strategy]() end
+  end
+
   if position.type == "file" then run_by_filename() end
 
   if position.type == "test" or position.type == "namespace" then run_by_line_number() end
@@ -138,6 +155,7 @@ function NeotestAdapter.build_spec(args)
       results_path = results_path,
       engine_name = engine_name,
     },
+    strategy = get_strategy_config(args.strategy, command, engine_name),
   }
 end
 


### PR DESCRIPTION
Allows debug tests to be invoked through neotest.

I've tested locally and it works as expected with nearest test, but it would also be worth testing with a minimal file. If you want me to add some tests for this I'm happy to 😄 

Thanks for a great package!