### PR TITLE
✨ Add support for user defined dap strategy

### DIFF
--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -1,5 +1,22 @@
 local M = {}
 
+M.get_strategy_config = function(strategy, command, cwd)
+  local strategy_config = {
+    dap = function()
+      return {
+        name = "Debug RSpec Tests",
+        type = "ruby",
+        args = { unpack(command, 2) },
+        command = command[1],
+        cwd = cwd or "${workspaceFolder}",
+        current_line = true,
+        random_port = true,
+      }
+    end,
+  }
+  if strategy_config[strategy] then return strategy_config[strategy]() end
+end
+
 M.get_rspec_cmd = function()
   return vim.tbl_flatten({
     "bundle",

--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -11,6 +11,9 @@ M.get_strategy_config = function(strategy, command, cwd)
         cwd = cwd or "${workspaceFolder}",
         current_line = true,
         random_port = true,
+        request = "attach",
+        error_on_failure = false,
+        localfs = true,
       }
     end,
   }

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -120,25 +120,6 @@ function NeotestAdapter.build_spec(args)
     )
   end
 
-  local function default_get_strategy_config(strategy, command, cwd)
-    local strategy_config = {
-      dap = function()
-        return {
-          name = "Debug RSpec Tests",
-          type = "ruby",
-          args = { unpack(command, 2) },
-          command = command[1],
-          cwd = cwd or "${workspaceFolder}",
-          current_line = true,
-          random_port = true,
-        }
-      end,
-    }
-    if strategy_config[strategy] then return strategy_config[strategy]() end
-  end
-
-  local get_strategy_config = config and config.get_strategy_config or default_get_strategy_config
-
   if position.type == "file" then run_by_filename() end
 
   if position.type == "test" or position.type == "namespace" then run_by_line_number() end
@@ -157,7 +138,7 @@ function NeotestAdapter.build_spec(args)
       results_path = results_path,
       engine_name = engine_name,
     },
-    strategy = get_strategy_config(args.strategy, command, engine_name),
+    strategy = config.get_strategy_config(args.strategy, command, engine_name),
   }
 end
 

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -213,6 +213,13 @@ setmetatable(NeotestAdapter, {
         return opts.results_path
       end
     end
+    if is_callable(opts.strategy_config) then
+      config.get_strategy_config = opts.strategy_config
+    elseif opts.strategy_config then
+      config.get_strategy_config = function()
+        return opts.strategy_config
+      end
+    end
     return NeotestAdapter
   end,
 })

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -120,7 +120,7 @@ function NeotestAdapter.build_spec(args)
     )
   end
 
-  local function get_strategy_config(strategy, command, cwd)
+  local function default_get_strategy_config(strategy, command, cwd)
     local strategy_config = {
       dap = function()
         return {
@@ -136,6 +136,8 @@ function NeotestAdapter.build_spec(args)
     }
     if strategy_config[strategy] then return strategy_config[strategy]() end
   end
+
+  local get_strategy_config = config and config.get_strategy_config or default_get_strategy_config
 
   if position.type == "file" then run_by_filename() end
 


### PR DESCRIPTION
## Why?

The default strategy configuration for `dap` does not work with current versions of `nvim-dap` or `nvim-dap-ruby`. It is missing the `request` field.

## What?

I am proposing enabling users to provide their own strategy config implementation so they can customize it to their needs.

## Alternatives

Change the existing `get_strategy_config` to include:

```lua
  request = "attach",
  error_on_failure = false,
  localfs = true,
  waiting = 1000,
```

## Todo

- [ ] Update documentation
- [x] Suppress exit code `1` warning for test failures
  - `error_on_failure = false,`
- [x] ~Fix inconsistent population of test output~
  - `dap-ruby` appends `stdout` to `dap.repl` instead of the process output tempfile
  - `dap-ruby` is configured as a `type = "server"` and it'll be challenging to capture the output stream as is
- [x] ~Fix inconsistent coloring of test output~
  - When `dap-ruby` runs the specs, it doesn't have a `TTY` -- so the `.rspec` configured `--color` is ignored.
  - If `--force-color` is set, then the `dap.repl` includes the color codes 

## Demo


https://github.com/user-attachments/assets/2d86ca90-69e5-4a74-84d0-0d259cab5a3e

