### PR TITLE
fix: update nvim-dap-ruby strategy config

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -131,6 +131,10 @@ function NeotestAdapter.build_spec(args)
           cwd = cwd or "${workspaceFolder}",
           current_line = true,
           random_port = true,
+          request = "attach",
+          error_on_failure = false, -- prevent nvim-dap-ruby from notifying user of exit code 1 from a test with failures.
+          localfs = true,
+          waiting = 1000,
         }
       end,
     }


### PR DESCRIPTION
## Why?

I get an error message:
> Config needs the `request` property which must be one of `attach` or `launch`

https://github.com/user-attachments/assets/2c24dd53-6f5b-4e77-94e5-a910139d603f

## What?

1. References [`nvim-dap-ruby`'s base ruby adapter configurations](https://github.com/suketa/nvim-dap-ruby/blob/4176405d186a93ebec38a6344df124b1689cfcfd/lua/dap-ruby.lua#L98) to resolve the above error message by adding `request = "attach",` to the return of `get_strategy_config`
2. Suppresses `exit code 1` notices from `nvim-dap-ruby` by configuring `error_on_failure = false`
3. Copies the `localfs = true,` and `waiting = 1000` configuration to match the [`nvim-dap-ruby`'s base run configuration](https://github.com/suketa/nvim-dap-ruby/blob/4176405d186a93ebec38a6344df124b1689cfcfd/lua/dap-ruby.lua#L99)

## Demo

1. Setting a breakpoint
2. Running `neotest` with `dap` strategy
3. `nvim-dap-ui` pops up
4. Continue from the break point
5. Observe test failure 

https://github.com/user-attachments/assets/e4839070-7c1c-4e4b-843e-e4bb2e89712b

Possible with the following Lazy configuration:

```lua
return {
  {
    "nvim-neotest/neotest",
    dependencies = {
      {
        "cpb/neotest-rspec",
        branch = "cpb/update-dap-strategy",
      },
      "nvim-neotest/nvim-nio",
      "nvim-lua/plenary.nvim",
      "antoinemadec/FixCursorHold.nvim",
      "nvim-treesitter/nvim-treesitter",
    },
    config = function()
      require("neotest").setup({
        adapters = {
          require("neotest-rspec")({
            rspec_cmd = function()
              return vim.tbl_flatten({
                "bundle",
                "exec",
                "rdbg",
                "--nonstop",
                "-c",
                "--",
                "rspec",
              })
            end,
          }),
        },
      })
    end,
  },
}
```