### PR TITLE
fix: add custom formatter to solve nested examples issue

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -84,6 +84,18 @@ function NeotestAdapter.discover_positions(path)
   })
 end
 
+local function get_formatter_path()
+  -- Get the directory of the current init.lua file
+  local plugin_root =
+    vim.fn.fnamemodify(vim.api.nvim_get_runtime_file("lua/neotest-rspec/init.lua", false)[1], ":h:h:h")
+
+  -- Construct the path to formatter.rb
+  local formatter_path = plugin_root .. "/neotest_formatter.rb"
+
+  -- Return the absolute path
+  return vim.fn.resolve(formatter_path)
+end
+
 ---@param args neotest.RunArgs
 ---@return neotest.RunSpec | nil
 function NeotestAdapter.build_spec(args)
@@ -98,9 +110,13 @@ function NeotestAdapter.build_spec(args)
   if match and match ~= 0 then engine_name = string.sub(path, 0, match - 1) end
   local results_path = config.results_path()
 
+  local formatter_path = get_formatter_path()
+
   local script_args = vim.tbl_flatten({
+    "--require",
+    formatter_path,
     "-f",
-    "json",
+    "NeotestFormatter",
     "-o",
     results_path,
     "-f",

--- a/neotest_formatter.rb
+++ b/neotest_formatter.rb
@@ -1,0 +1,22 @@
+require "rspec/core/formatters/json_formatter"
+
+class NeotestFormatter < RSpec::Core::Formatters::JsonFormatter
+  RSpec::Core::Formatters.register self, :message, :dump_summary, :dump_profile, :stop, :seed, :close
+
+  private
+
+  def get_actual_inclusion_line_number(example)
+    if example.metadata[:shared_group_inclusion_backtrace]&.any?
+      example.metadata[:shared_group_inclusion_backtrace].first.inclusion_location[/(?<=:)\d+(?=:in)/]
+    else
+      example.metadata[:line_number]
+    end
+  end
+
+  def format_example(example)
+    result = super(example)
+    result.merge(
+      line_number: get_actual_inclusion_line_number(example)
+    )
+  end
+end


### PR DESCRIPTION
This PR fixes #74 by shipping a custom formatter with the plugin and referencing it when running the tests instead of the built-in JSON formatter. 

All tests are now passing in the repo with this patch applied.
![CleanShot 2024-12-01 at 20 27 25@2x](https://github.com/user-attachments/assets/596e6bac-9ccf-46ea-bd5b-48dacb87852f)
