### PR TITLE
Add support for RSpec's #include_examples too

### DIFF
--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -72,7 +72,7 @@ function NeotestAdapter.discover_positions(path)
     )) @test.definition
 
     ((call
-      method: (identifier) @func_name (#match? @func_name "^(it|its|scenario|it_behaves_like)$")
+      method: (identifier) @func_name (#match? @func_name "^(it|its|scenario|include_examples|it_behaves_like)$")
       arguments: (argument_list (_) @test.name)
     )) @test.definition
   ]]


### PR DESCRIPTION
Following on from #74 and #75 (❤️), this PR adds support for RSpec's `include_examples` method, for adding shared examples to the current context.