### PR TITLE
Add `formatter` configuration option to perform tests in Docker environment

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,6 +78,9 @@ adapters = {
     end,
     results_path = function()
       return async.fn.tempname()
+    end,
+    formatter = function()
+      return "NeotestFormatter"
     end
   }),
 }
@@ -190,7 +193,7 @@ require("neotest-rspec")({
 
 ### Running tests in a Docker container
 
-The following configuration overrides `rspec_cmd` to run a Docker container (using `docker-compose`) and overrides `transform_spec_path` to pass the spec file as a relative path instead of an absolute path to RSpec. The `results_path` needs to be set to a location which is available to both the container and the host.
+The following configuration overrides `rspec_cmd` to run a Docker container (using `docker-compose`) and overrides `transform_spec_path` to pass the spec file as a relative path instead of an absolute path to RSpec. The `results_path` needs to be set to a location which is available to both the container and the host. Additionally, to avoid using a custom formatter, you need to specify `formatter = "json"`.
 
 ```lua
 require("neotest").setup({
@@ -216,7 +219,8 @@ require("neotest").setup({
         return string.sub(path, string.len(prefix) + 2, -1)
       end,
 
-      results_path = "tmp/rspec.output"
+      results_path = "tmp/rspec.output",
+      formatter = "json"
     })
   }
 })

--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -24,4 +24,8 @@ M.results_path = function()
   return require("neotest.async").fn.tempname()
 end
 
+M.formatter = function()
+  return "NeotestFormatter"
+end
+
 return M

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -111,17 +111,24 @@ function NeotestAdapter.build_spec(args)
   local results_path = config.results_path()
 
   local formatter_path = get_formatter_path()
+  local formatter = config.formatter()
 
-  local script_args = vim.tbl_flatten({
-    "--require",
-    formatter_path,
+  local script_args = {
     "-f",
-    "NeotestFormatter",
+    formatter,
     "-o",
     results_path,
     "-f",
     "progress",
-  })
+  }
+
+  if formatter == "NeotestFormatter" then
+    script_args = vim.tbl_flatten({
+      "--require",
+      formatter_path,
+      script_args,
+    })
+  end
 
   local function run_by_filename()
     table.insert(script_args, spec_path)
@@ -244,6 +251,13 @@ setmetatable(NeotestAdapter, {
     elseif opts.results_path then
       config.results_path = function()
         return opts.results_path
+      end
+    end
+    if is_callable(opts.formatter) then
+      config.formatter = opts.formatter
+    elseif opts.formatter then
+      config.formatter = function()
+        return opts.formatter
       end
     end
     return NeotestAdapter


### PR DESCRIPTION
## What changed:

This PR resolves the issue #77  where tests could not be executed in a Docker environment due to a custom formatter load error by adding a formatter configuration option.

The load error occurred because `neotest_formatter.rb` exists in the user’s local environment but not in the Docker container environment, and the custom formatter was specified by default.

The default value of the formatter option remains `NeotestFormatter`, so it does not affect existing test executions. For test executions in a Docker environment, the load error can be resolved by setting the formatter option to "json".

## What this PR does not address:

This is an existing bug, but when running tests in a Docker environment that include `shared_examples`, an error occurs. Allowing the use of a custom formatter in a Docker environment could potentially resolve this issue.