### PR TITLE
Fix broken engine support

### DIFF
--- a/README.md
+++ b/README.md
@@ -76,6 +76,7 @@ adapters = {
     transform_spec_path = function(path)
       return path
     end,
+    engine_support = true,
     results_path = function()
       return async.fn.tempname()
     end,
@@ -188,6 +189,18 @@ You can even set `filter_dirs` with a function which returns a table:
 ```lua
 require("neotest-rspec")({
   filter_dirs = function() return { "my_custom_dir" } end
+})
+```
+
+### Running engine tests
+
+By default, the adapter will run specs from the directory that contains the `spec/` directory. This means that nested engines' specs will be run in an isolated way from within the engine.
+
+You can opt out of this behaviour and always run specs from the project root:
+
+```lua
+require("neotest-rspec")({
+  engine_support = false
 })
 ```
 

--- a/engine/spec/engine_spec.rb
+++ b/engine/spec/engine_spec.rb
@@ -1,0 +1,5 @@
+RSpec.describe 'Engine support' do
+  it 'runs specs from the engine root' do
+    expect(Dir.pwd).to end_with('/engine')
+  end
+end

--- a/engine/spec/engine_spec_01.commands
+++ b/engine/spec/engine_spec_01.commands
@@ -1,0 +1,2 @@
+:1
+:lua require("neotest").run.run()

--- a/engine/spec/engine_spec_01.expected
+++ b/engine/spec/engine_spec_01.expected
@@ -1,0 +1,1 @@
+./SPEC/ENGINE_SPEC.RB@@PASSED@@runs specs from the engine root

--- a/engine/spec/engine_spec_02.commands
+++ b/engine/spec/engine_spec_02.commands
@@ -1,0 +1,3 @@
+:lua require("neotest-rspec")({engine_support=false})
+:1
+:lua require("neotest").run.run()

--- a/engine/spec/engine_spec_02.expected
+++ b/engine/spec/engine_spec_02.expected
@@ -1,0 +1,1 @@
+./ENGINE/SPEC/ENGINE_SPEC.RB@@FAILED@@runs specs from the engine root

--- a/lua/neotest-rspec/config.lua
+++ b/lua/neotest-rspec/config.lua
@@ -20,6 +20,8 @@ M.transform_spec_path = function(path)
   return path
 end
 
+M.engine_support = true
+
 M.results_path = function()
   return require("neotest.async").fn.tempname()
 end

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -106,7 +106,7 @@ function NeotestAdapter.build_spec(args)
   local path = async.fn.expand("%")
 
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
-  local match = vim.regex("^spec/"):match_str(path)
+  local match = vim.regex("spec/"):match_str(path)
   if match and match ~= 0 then engine_name = string.sub(path, 0, match - 1) end
   local results_path = config.results_path()
 

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -105,9 +105,12 @@ function NeotestAdapter.build_spec(args)
   local spec_path = config.transform_spec_path(position.path)
   local path = vim.fn.fnamemodify(async.fn.expand("%"), ":.")
 
-  -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
-  local match = vim.regex("spec/"):match_str(path)
-  if match and match ~= 0 then engine_name = string.sub(path, 0, match - 1) end
+  if config.engine_support then
+    -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
+    local match = vim.regex("spec/"):match_str(path)
+    if match and match ~= 0 then engine_name = string.sub(path, 0, match - 1) end
+  end
+
   local results_path = config.results_path()
 
   local formatter_path = get_formatter_path()
@@ -256,6 +259,9 @@ setmetatable(NeotestAdapter, {
       config.results_path = function()
         return opts.results_path
       end
+    end
+    if opts.engine_support ~= nil then
+      config.engine_support = opts.engine_support
     end
     if is_callable(opts.formatter) then
       config.formatter = opts.formatter

--- a/lua/neotest-rspec/init.lua
+++ b/lua/neotest-rspec/init.lua
@@ -93,7 +93,7 @@ local function get_formatter_path()
   local formatter_path = plugin_root .. "/neotest_formatter.rb"
 
   -- Return the absolute path
-  return vim.fn.resolve(formatter_path)
+  return vim.fn.fnamemodify(formatter_path, ":p")
 end
 
 ---@param args neotest.RunArgs
@@ -103,7 +103,7 @@ function NeotestAdapter.build_spec(args)
   local engine_name = nil
 
   local spec_path = config.transform_spec_path(position.path)
-  local path = async.fn.expand("%")
+  local path = vim.fn.fnamemodify(async.fn.expand("%"), ":.")
 
   -- if the path starts with spec, it's a normal test. Otherwise, it's an engine test
   local match = vim.regex("spec/"):match_str(path)

--- a/tests/template.lua
+++ b/tests/template.lua
@@ -9,6 +9,12 @@ local function assert_skipped(reason)
 end
 
 local function for_each_test_file(test, callback)
+  -- If given a full relative path, use it directly
+  local test_path = Path:new(cwd, test):absolute()
+  if vim.loop.fs_stat(test_path) then
+    callback(test_path)
+    return
+  end
   local files = scandir.scan_dir(Path:new(cwd, "spec"):absolute())
   for _, file in pairs(files) do
     if string.match(file, test) then

--- a/tests/unit/rspec/engine_spec.lua
+++ b/tests/unit/rspec/engine_spec.lua
@@ -1,0 +1,3 @@
+local test = require("tests.template")
+
+test.describe("Testing engine specs", "engine/spec/engine_spec.rb")


### PR DESCRIPTION
Support for running specs for isolated engines was originally added in #34. However, it was broken by a tweak made in #49 that wanted to support running nested spec suites from the project root instead.

I may have got this wrong, but I'm interpreting that as inadvertent breakage for engines (as none of the supporting code was removed), so I'm submitting this PR to restore the original behaviour. As it is evidently not behaviour that everyone prefers, I've suggested an `engine_support = true` default configuration; those that would rather continue with the "broken" behaviour could change this to opt out. But it could equally make sense to continue with the current behaviour as the default, and allow opt in back to the original enhanced support?

I've added some new coverage, as it looks to me like the original coverage got lost during #38. 

